### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ configuration.nix
 
 environment.systemPackages = [
 ...
-    inputs.klassy.packages.${system}.klassy
+    inputs.klassy.packages.${system}.default
 ];
 ```


### PR DESCRIPTION
Example updated to to default package in flake output.
Since klassy as a package is not output, only default and klassy-qt6.